### PR TITLE
Fix Exception `AttributeError`

### DIFF
--- a/src/newrelic_logging/auth.py
+++ b/src/newrelic_logging/auth.py
@@ -115,7 +115,7 @@ class Authenticator:
                 private_key = f.read()
                 key = serialization.load_ssh_private_key(private_key.encode(), password=b'')
             except ValueError as e:
-                raise LoginException(f'authentication failed for {self.instance_name}. error message: {str(e)}')
+                raise LoginException(f'authentication failed for {self.instance_url}. error message: {str(e)}')
 
         jwt_claim_set = {
             "iss": client_id,
@@ -150,9 +150,9 @@ class Authenticator:
 
             self.store_auth(resp.json())
         except ConnectionError as e:
-            raise LoginException(f'authentication failed for sfdc instance {self.instance_name}') from e
+            raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
         except RequestException as e:
-            raise LoginException(f'authentication failed for sfdc instance {self.instance_name}') from e
+            raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
 
     def authenticate_with_password(self, session: Session) -> None:
         client_id = self.auth_data['client_id']
@@ -182,9 +182,9 @@ class Authenticator:
 
             self.store_auth(resp.json())
         except ConnectionError as e:
-            raise LoginException(f'authentication failed for sfdc instance {self.instance_name}') from e
+            raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
         except RequestException as e:
-            raise LoginException(f'authentication failed for sfdc instance {self.instance_name}') from e
+            raise LoginException(f'authentication failed for sfdc instance {self.instance_url}') from e
 
     def authenticate(self, session: Session) -> None:
         if self.data_cache and self.load_auth_from_cache():


### PR DESCRIPTION
### Issue

https://github.com/newrelic/newrelic-salesforce-exporter/issues/54#issuecomment-2736405275

### Comments

Instead of `instance_name`, I'm printing `instance_url`, which is enough to identify the instance that originated the `LoginException`. The `Authenticator` class doesn't have access to `instance_name`, and making it get there will require changing the signature of various methods and classes: `Factory.new_instance` -> `Factory.new_authenticator` -> `Authenticator`. I don't think it's worth it for just prettifying an error message.